### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/src/main/java/com/futureprocessing/spring/infrastructure/ServiceGatewayImpl.java
+++ b/src/main/java/com/futureprocessing/spring/infrastructure/ServiceGatewayImpl.java
@@ -4,11 +4,11 @@ import com.futureprocessing.spring.api.samplestuff.ServiceGateway;
 import com.futureprocessing.spring.domain.DomainUser;
 import com.futureprocessing.spring.domain.Stuff;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Component
+@Service
 public class ServiceGatewayImpl extends ServiceGatewayBase implements ServiceGateway {
 
     @Autowired


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the service layer should be annotated using @service instead of @component annotation.
@service annotation is a specialization of @component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @service is a better choice.